### PR TITLE
Add Vector Store Agent to A2A samples

### DIFF
--- a/samples/python/agents/README.md
+++ b/samples/python/agents/README.md
@@ -17,3 +17,6 @@ Sample agent which can generate images. Showcases multi-turn interactions and se
 
 * [**LlamaIndex**](/samples/python/agents/llama_index_file_chat/README.md)  
 Sample agent which can parse a file and then chat with the user using the parsed content as context. Showcases multi-turn interactions, file upload and parsing, and streaming updates. 
+
+* [**Vector Store Agent**](/samples/python/agents/vector_store_agent/README.md)  
+Sample agent which can query OpenAI vector stores using natural language.

--- a/samples/python/agents/vector_store_agent/README.md
+++ b/samples/python/agents/vector_store_agent/README.md
@@ -1,0 +1,134 @@
+# Vector Store Knowledge Agent
+
+A general-purpose A2A agent that provides information from an OpenAI vector store using the Responses API.
+
+## Overview
+
+The Vector Store Knowledge Agent is an A2A (Agent-to-Agent) compliant agent that enables querying and retrieving information from any OpenAI vector store. This agent is designed to be versatile and configurable, allowing it to work with different vector stores containing various types of knowledge, from documentation to specialized domain information.
+
+## Features
+
+- **OpenAI Vector Store Integration**: Connect to any OpenAI vector store by simply providing the vector store ID
+- **Streaming Support**: Stream responses in real-time for a better user experience
+- **Configurable**: Customize the model, maximum results, and prompt template to fit your needs
+- **Mock Mode**: Automatically falls back to mock responses when no vector store is available
+- **A2A Protocol Compatibility**: Fully compatible with the A2A protocol for seamless integration with other agents
+
+## How It Works
+
+This agent uses OpenAI's Responses API with the `file_search` tool to query a specified vector store.
+
+```mermaid
+sequenceDiagram
+    participant Client as A2A Client
+    participant Server as Vector Store A2A Server
+    participant Agent as VectorStoreAgent Logic
+    participant OpenAI as OpenAI Responses API
+
+    Client->>Server: Send task with query (tasks/send or tasks/sendSubscribe)
+    Server->>Agent: Forward query
+
+    alt Synchronous (tasks/send)
+        Agent->>OpenAI: Create Response (using file_search)
+        OpenAI-->>Agent: Return Response object
+        Agent->>Server: Process response into text result
+        Server->>Client: Return completed Task object with result artifact
+    else Streaming (tasks/sendSubscribe)
+        Server-->>Client: Stream TaskStatusUpdateEvent (state=WORKING, text="Starting query...")
+        Agent->>OpenAI: Create Response (using file_search)
+        OpenAI-->>Agent: Return Response object
+        Agent->>Server: Process response into text result
+        Note over Server, Client: Simulation: Full result returned after initial status due to current code/API limitations.
+        Server-->>Client: Stream TaskArtifactUpdateEvent (with full result)
+        Server-->>Client: Stream TaskStatusUpdateEvent (state=COMPLETED, final=true)
+    end
+```
+
+## Prerequisites
+
+- Python 3.13 or higher
+- OpenAI API key with access to the Responses API and vector stores
+- A2A framework
+
+## Setup & Running
+
+### Running the Server
+
+The easiest way to run the agent is using the provided entry point:
+
+```bash
+# Set your OpenAI API key and vector store ID
+export OPENAI_API_KEY=your-openai-api-key
+export VECTOR_STORE_ID=your-vector-store-id
+
+# Navigate to the agent directory
+cd samples/python/agents/vector_store_agent
+
+# Run the server
+uv run .
+
+# Optionally specify host and port
+# uv run . --host 0.0.0.0 --port 8080
+```
+
+This will start an A2A server on localhost port 10050 (or your specified port).
+
+### Querying the Agent
+
+Once the server is running, you can query it using any A2A-compatible client:
+
+```bash
+# Navigate to the CLI directory
+cd samples/python/hosts/cli
+
+# Run the CLI client against your agent
+uv run . --agent http://localhost:10050
+```
+
+## Configuration
+
+The agent can be configured through environment variables:
+
+| Environment Variable | Description | Default |
+|----------------------|-------------|---------|
+| `OPENAI_API_KEY` | Your OpenAI API key | Required |
+| `VECTOR_STORE_ID` | The ID of your OpenAI vector store | Required for non-mock mode |
+| `VECTOR_STORE_MODEL` | The OpenAI model to use | `gpt-4.1-mini` |
+| `VECTOR_STORE_HOST` | The host to run the A2A server on | `localhost` |
+| `VECTOR_STORE_PORT` | The port to run the A2A server on | `10050` |
+| `VECTOR_STORE_MAX_RESULTS` | Maximum number of results to return | `5` |
+| `VECTOR_STORE_ENABLE_STREAMING` | Enable/disable streaming responses | `true` |
+| `VECTOR_STORE_CHUNK_SIZE` | Character size of streaming chunks | `20` |
+
+## Creating a Vector Store
+
+To use this agent effectively, you need to create an OpenAI vector store:
+
+1. Prepare your documents for ingestion into a vector store
+2. Use OpenAI's API to create a vector store with your documents
+3. Obtain the vector store ID
+4. Configure the agent with your vector store ID
+
+For detailed instructions on vector store searching with the file_search tool, refer to the [OpenAI documentation](https://platform.openai.com/docs/guides/tools-file-search).
+
+## Customizing the Agent
+
+### Prompt Template
+
+You can customize the prompt template by modifying the `DEFAULT_MODEL_PROMPT` in the `config.py` file. The prompt template should include a `{query}` placeholder that will be replaced with the user's query.
+
+### Adding Custom Functionality
+
+The agent is designed to be extensible. To add custom functionality:
+
+1. Modify the `VectorStoreAgent` class in `agent.py`
+2. Add your custom logic to the `process_query` and `stream_query` methods
+3. Update the configuration as needed
+
+## License
+
+This project is licensed under the terms of the Apache 2.0 license - see the LICENSE file for details.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.

--- a/samples/python/agents/vector_store_agent/__main__.py
+++ b/samples/python/agents/vector_store_agent/__main__.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+Vector Store Knowledge Agent - Main Entry Point
+
+This file serves as the main entry point for the Vector Store Agent.
+It initializes the A2A server with the vector store agent capabilities
+and handles command-line configuration.
+"""
+
+import os
+import click
+import logging
+from pathlib import Path
+import sys
+
+# This allows the module to be run directly with 'python -m' or 'uv run .'
+# and properly find the A2A common modules
+parent_dir = Path(__file__).parent.parent.parent.parent.parent
+if str(parent_dir) not in sys.path:
+    sys.path.insert(0, str(parent_dir))
+
+from samples.python.agents.vector_store_agent.agent import VectorStoreAgent, run_server
+from samples.python.agents.vector_store_agent.config import DEFAULT_HOST, DEFAULT_PORT, VECTOR_STORE_ID, DEFAULT_MODEL
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@click.command()
+@click.option("--host", default=DEFAULT_HOST, help="Host to run the server on")
+@click.option("--port", default=DEFAULT_PORT, help="Port to run the server on")
+def main(host, port):
+    """Entry point for the Vector Store Knowledge Agent."""
+    # Display startup information
+    print("Starting Vector Store Agent server...")
+    print(f"Host: {host}")
+    print(f"Port: {port}")
+    print(f"Vector Store ID: {VECTOR_STORE_ID or 'Not set (using mock mode)'}")
+    print(f"Model: {DEFAULT_MODEL}")
+    print("\nUse Ctrl+C to stop the server")
+    print("\nYou can query this agent using an A2A compatible client, e.g.:")
+    print(f"cd samples/python/hosts/cli && uv run . --agent http://localhost:{port}")
+    
+    # Start the server with configured host and port
+    run_server(host=host, port=port)
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/agents/vector_store_agent/agent.py
+++ b/samples/python/agents/vector_store_agent/agent.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""
+Vector Store Knowledge Agent
+
+A general-purpose A2A agent that provides information from an OpenAI vector store.
+This agent uses OpenAI's Responses API to query any vector store and return relevant
+information based on the user's query.
+"""
+
+import os
+import logging
+import asyncio
+from typing import Dict, Any, Optional, List, Generator, AsyncGenerator
+
+try:
+    from openai import OpenAI
+except ImportError:
+    print("Error: OpenAI package not installed. Install with 'pip install openai'")
+    exit(1)
+
+from common.types import (
+    Message,
+    TextPart,
+    TaskState, 
+    TaskStatus,
+    Task,
+    SendTaskRequest,
+    SendTaskResponse,
+    SendTaskStreamingRequest,
+    SendTaskStreamingResponse,
+    TaskStatusUpdateEvent,
+    TaskArtifactUpdateEvent,
+    Artifact,
+    AgentCard,
+    AgentProvider,
+    AgentCapabilities,
+    AgentSkill,
+)
+
+from common.server import A2AServer, InMemoryTaskManager
+from .config import (
+    OPENAI_API_KEY,
+    DEFAULT_MODEL,
+    VECTOR_STORE_ID,
+    USE_MOCK,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    AGENT_NAME,
+    AGENT_DESCRIPTION,
+    AGENT_ORGANIZATION,
+    DEFAULT_MAX_RESULTS,
+    DEFAULT_MODEL_PROMPT,
+    MOCK_RESPONSE_TEMPLATE,
+    ENABLE_STREAMING,
+    STREAMING_CHUNK_SIZE,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+class VectorStoreAgent:
+    def __init__(self, openai_client=None, vector_store_id=None):
+        """
+        Initialize the Vector Store Agent with the necessary configurations.
+
+        Args:
+            openai_client: OpenAI client, if None a new one will be created
+            vector_store_id: ID of the vector store to query
+        """
+        self.openai_client = openai_client or OpenAI(api_key=OPENAI_API_KEY)
+        self.vector_store_id = vector_store_id or VECTOR_STORE_ID
+        self.use_mock = (
+            not self.vector_store_id or self.vector_store_id == "mock-store-id"
+        )
+
+        if self.use_mock:
+            logger.warning("No vector store ID provided. Using mock responses.")
+        else:
+            logger.info(f"Using vector store ID: {self.vector_store_id}")
+
+        self.model = DEFAULT_MODEL
+        self.max_results = DEFAULT_MAX_RESULTS
+        self.prompt_template = DEFAULT_MODEL_PROMPT
+
+    async def process_query(self, query: str) -> str:
+        """
+        Process a user query by searching the vector store and returning relevant information.
+
+        Args:
+            query: The user's query string
+
+        Returns:
+            A formatted string response containing information from the vector store
+        """
+        if self.use_mock:
+            return MOCK_RESPONSE_TEMPLATE.format(query=query)
+
+        try:
+            logger.info(
+                f"Querying vector store for: '{query}' using Vector Store: {self.vector_store_id}"
+            )
+            logger.info(f"Using model: {self.model}")
+
+            response = self.openai_client.responses.create(
+                input=self.prompt_template.format(query=query),
+                model=self.model,
+                tools=[
+                    {"type": "file_search", "vector_store_ids": [self.vector_store_id]}
+                ],
+                tool_choice={"type": "file_search"},
+            )
+
+            assistant_response = "Error: Could not extract response from API output."
+            if response.output:
+                for output_item in response.output:
+                    if (
+                        hasattr(output_item, "role")
+                        and output_item.role == "assistant"
+                        and hasattr(output_item, "content")
+                        and output_item.content
+                    ):
+                        if hasattr(output_item.content[0], "text"):
+                            assistant_response = output_item.content[0].text
+                            break
+
+            model_info = f"\n\n_Response generated using {self.model}_"
+            return assistant_response + model_info
+
+        except Exception as e:
+            logger.error(f"Error querying vector store: {e}")
+            return f"Error: Unable to query the vector store. {str(e)}"
+
+    async def stream_query(self, query: str) -> AsyncGenerator[str, None]:
+        """
+        Stream a response from the vector store for a given query.
+
+        Args:
+            query: The user's query string
+
+        Yields:
+            Chunks of the response as they become available
+        """
+        if self.use_mock:
+            yield MOCK_RESPONSE_TEMPLATE.format(query=query)
+            return
+
+        try:
+            logger.info(
+                f"Streaming response for query: '{query}' using Vector Store: {self.vector_store_id}"
+            )
+            logger.info(f"Using model: {self.model}")
+            
+            stream = self.openai_client.responses.create(
+                input=self.prompt_template.format(query=query),
+                model=self.model,
+                tools=[
+                    {"type": "file_search", "vector_store_ids": [self.vector_store_id]}
+                ],
+                tool_choice={"type": "file_search"},
+                stream=True,
+            )
+            
+            assistant_response = ""
+            model_info_added = False
+            
+            for chunk in stream:
+                logger.debug(f"Received chunk type: {type(chunk).__name__}")
+                
+                text_chunk = None
+                
+                if hasattr(chunk, "choices") and chunk.choices:
+                    choice = chunk.choices[0]
+                    if hasattr(choice, "delta") and hasattr(choice.delta, "content"):
+                        text_chunk = choice.delta.content
+                elif hasattr(chunk, "delta"):
+                    text_chunk = chunk.delta
+                elif hasattr(chunk, "content"):
+                    text_chunk = chunk.content
+                
+                if text_chunk:
+                    assistant_response += text_chunk
+                    yield text_chunk
+            
+            if not model_info_added:
+                model_info = f"\n\n_Response generated using {self.model}_"
+                assistant_response += model_info
+                yield model_info
+                    
+        except Exception as e:
+            logger.error(f"Error streaming from vector store: {e}")
+            yield f"Error: Unable to stream from the vector store. {str(e)}"
+
+
+class VectorStoreTaskManager(InMemoryTaskManager):
+    def __init__(self, agent: VectorStoreAgent):
+        """
+        Initialize the task manager with the Vector Store Agent.
+
+        Args:
+            agent: The VectorStoreAgent instance to use for processing queries
+        """
+        super().__init__()
+        self.agent = agent
+
+    def _extract_query(self, params: Any) -> str:
+        """Helper to extract text query from task parameters."""
+        message_text = ""
+        if params and hasattr(params, "message") and hasattr(params.message, "parts"):
+            for part in params.message.parts:
+                if hasattr(part, "text"):
+                    message_text += part.text
+        if not message_text:
+            logger.warning("Could not extract text query from message parts.")
+            raise ValueError("No text query found in the message.")
+        logger.info(f"Extracted message text: '{message_text}'")
+        return message_text
+
+    async def _invoke_agent(self, query: str, task_id: str, session_id: str) -> Task:
+        """Handles the synchronous agent invocation and task update."""
+        try:
+            result = await self.agent.process_query(query)
+            status = TaskStatus(
+                state=TaskState.COMPLETED,
+                message=Message(
+                    role="agent", parts=[TextPart(type="text", text=result)]
+                ),
+            )
+            task = await self.update_store(
+                task_id,
+                status,
+                [
+                    Artifact(parts=[TextPart(type="text", text=result)])
+                ],
+            )
+            return task
+        except Exception as e:
+            logger.error(f"Error invoking agent for task {task_id}: {e}", exc_info=True)
+            status = TaskStatus(
+                state=TaskState.FAILED,
+                message=Message(
+                    role="agent", parts=[TextPart(type="text", text=f"Error: {str(e)}")]
+                ),
+            )
+            task = await self.update_store(task_id, status, None)
+            return task
+
+    async def _run_streaming_agent(
+        self, query: str, task_id: str, session_id: str
+    ) -> AsyncGenerator[Task, None]:
+        """Handles the streaming agent invocation and yields task updates."""
+        initial_status = TaskStatus(
+            state=TaskState.WORKING,
+            message=Message(
+                role="agent",
+                parts=[TextPart(type="text", text="Starting vector store query...")],
+            ),
+        )
+        task = await self.update_store(task_id, initial_status, None)
+        yield task
+
+        try:
+            if not ENABLE_STREAMING:
+                result = await self.agent.process_query(query)
+                final_status = TaskStatus(
+                    state=TaskState.COMPLETED,
+                    message=Message(
+                        role="agent", parts=[TextPart(type="text", text=result)]
+                    ),
+                )
+                task = await self.update_store(
+                    task_id,
+                    final_status,
+                    [
+                        Artifact(parts=[TextPart(type="text", text=result)])
+                    ],
+                )
+                yield task
+                return
+
+            full_response = ""
+            current_chunk = ""
+            chunk_size = STREAMING_CHUNK_SIZE
+            
+            async for chunk in self.agent.stream_query(query):
+                full_response += chunk
+                current_chunk += chunk
+                
+                if len(current_chunk) >= chunk_size:
+                    chunk_status = TaskStatus(
+                        state=TaskState.WORKING,
+                        message=Message(
+                            role="agent",
+                            parts=[TextPart(type="text", text=current_chunk)],
+                        ),
+                    )
+                    task = await self.update_store(task_id, chunk_status, None)
+                    yield task
+                    
+                    current_chunk = ""
+            
+            if current_chunk:
+                chunk_status = TaskStatus(
+                    state=TaskState.WORKING,
+                    message=Message(
+                        role="agent",
+                        parts=[TextPart(type="text", text=current_chunk)],
+                    ),
+                )
+                task = await self.update_store(task_id, chunk_status, None)
+                yield task
+
+            final_status = TaskStatus(
+                state=TaskState.COMPLETED,
+                message=Message(
+                    role="agent", parts=[TextPart(type="text", text=full_response)]
+                ),
+            )
+            task = await self.update_store(
+                task_id,
+                final_status,
+                [
+                    Artifact(parts=[TextPart(type="text", text=full_response)])
+                ],
+            )
+            yield task
+        except Exception as e:
+            logger.error(
+                f"Error during agent streaming for task {task_id}: {e}", exc_info=True
+            )
+            final_status = TaskStatus(
+                state=TaskState.FAILED,
+                message=Message(
+                    role="agent", parts=[TextPart(type="text", text=f"Error: {str(e)}")]
+                ),
+            )
+            task = await self.update_store(task_id, final_status, None)
+            yield task
+
+    async def on_send_task(self, request: SendTaskRequest) -> SendTaskResponse:
+        """
+        Handle a send task request synchronously.
+
+        Args:
+            request: The task request parameters
+
+        Returns:
+            Response containing the task results
+        """
+        params = request.params
+        logger.info(f"Received task request: {params}")
+
+        if not params or not params.message or not params.message.parts:
+            logger.error("Invalid task request parameters.")
+            raise ValueError("Invalid task parameters")
+
+        await self.upsert_task(params)
+        await self.update_store(params.id, TaskStatus(state=TaskState.WORKING), None)
+
+        try:
+            query = self._extract_query(params)
+            task_result = await self._invoke_agent(query, params.id, params.sessionId)
+            return SendTaskResponse(id=request.id, result=task_result)
+
+        except Exception as e:
+            logger.error(f"Error processing task {params.id}: {e}", exc_info=True)
+            status = TaskStatus(
+                state=TaskState.FAILED,
+                message=Message(
+                    role="agent",
+                    parts=[TextPart(text=f"Internal Server Error: {str(e)}")],
+                ),
+            )
+            try:
+                failed_task = await self.update_store(params.id, status, None)
+                return SendTaskResponse(id=request.id, result=failed_task)
+            except Exception as update_err:
+                logger.error(
+                    f"Failed to update task {params.id} to FAILED state: {update_err}"
+                )
+                raise
+
+    async def on_send_task_subscribe(
+        self, request: SendTaskStreamingRequest
+    ) -> AsyncGenerator[SendTaskStreamingResponse, None]:
+        """
+        Handle a streaming task request.
+
+        Args:
+            request: The task request parameters
+
+        Yields:
+            Task updates wrapped in SendTaskStreamingResponse
+        """
+        params = request.params
+        logger.info(f"Received streaming task request: {params.id}")
+
+        if not params or not params.message or not params.message.parts:
+            logger.error("Invalid streaming task request parameters.")
+            raise ValueError("Invalid task parameters")
+
+        await self.upsert_task(params)
+        await self.update_store(params.id, TaskStatus(state=TaskState.WORKING), None)
+
+        sse_event_queue = await self.setup_sse_consumer(params.id, is_resubscribe=False)
+
+        try:
+            query = self._extract_query(params)
+
+            async def event_producer():
+                try:
+                    async for task_update in self._run_streaming_agent(
+                        query, params.id, params.sessionId
+                    ):
+                        event = TaskStatusUpdateEvent(
+                            id=task_update.id,
+                            status=task_update.status,
+                            final=(
+                                task_update.status.state
+                                in [
+                                    TaskState.COMPLETED,
+                                    TaskState.FAILED,
+                                    TaskState.CANCELED,
+                                ]
+                            ),
+                        )
+                        await self.enqueue_events_for_sse(params.id, event)
+
+                        if (
+                            task_update.status.state == TaskState.COMPLETED
+                            and task_update.artifacts
+                        ):
+                            for artifact in task_update.artifacts:
+                                artifact_event = TaskArtifactUpdateEvent(
+                                    id=task_update.id, artifact=artifact
+                                )
+                                await self.enqueue_events_for_sse(
+                                    params.id, artifact_event
+                                )
+
+                except Exception as e:
+                    logger.error(
+                        f"Error in event producer for task {params.id}: {e}",
+                        exc_info=True,
+                    )
+                    error_status = TaskStatus(
+                        state=TaskState.FAILED,
+                        message=Message(
+                            role="agent",
+                            parts=[TextPart(text=f"Streaming Error: {str(e)}")],
+                        ),
+                    )
+                    error_event = TaskStatusUpdateEvent(
+                        id=params.id, status=error_status, final=True
+                    )
+                    await self.enqueue_events_for_sse(params.id, error_event)
+                finally:
+                    logger.info(f"Event producer finished for task {params.id}")
+
+            asyncio.create_task(event_producer())
+
+            return self.dequeue_events_for_sse(request.id, params.id, sse_event_queue)  # type: ignore
+
+        except Exception as e:
+            logger.error(
+                f"Error setting up streaming for task {params.id}: {e}", exc_info=True
+            )
+            raise
+
+
+def run_server(host="0.0.0.0", port=10050):
+    """Initialize and run the A2A server with the Vector Store agent"""
+
+    openai_api_key = os.environ.get("OPENAI_API_KEY")
+    if not openai_api_key:
+        logger.warning(
+            "OPENAI_API_KEY environment variable not set. Some features may not work."
+        )
+
+    vector_store_id = os.environ.get("VECTOR_STORE_ID")
+    if not vector_store_id:
+        logger.warning("VECTOR_STORE_ID environment variable not set. Using mock mode.")
+        vector_store_id = "mock-store-id"
+
+    logger.info(f"Using Vector Store ID: {vector_store_id}")
+
+    logger.info("Initializing Vector Store Agent...")
+    openai_client = OpenAI(api_key=openai_api_key)
+    vector_store_agent = VectorStoreAgent(openai_client, vector_store_id)
+
+    logger.info("Initializing Task Manager...")
+    task_manager = VectorStoreTaskManager(vector_store_agent)
+
+    logger.info("Configuring A2A Server...")
+    agent_card = AgentCard(
+        name=AGENT_NAME,
+        description=AGENT_DESCRIPTION,
+        url=f"http://{host}:{port}/",
+        provider=AgentProvider(organization=AGENT_ORGANIZATION),
+        version="1.0.0",
+        capabilities=AgentCapabilities(
+            streaming=True, pushNotifications=False, stateTransitionHistory=False
+        ),
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
+        skills=[
+            AgentSkill(
+                id="vector_store_knowledge_retrieval",
+                name="vector_store_knowledge_retrieval",
+                description="Retrieve information from a vector store based on natural language queries",
+            )
+        ],
+    )
+
+    server = A2AServer(
+        host=host,
+        port=port,
+        endpoint="/",
+        agent_card=agent_card,
+        task_manager=task_manager,
+    )
+
+    server.start()
+
+
+if __name__ == "__main__":
+    run_server()

--- a/samples/python/agents/vector_store_agent/config.py
+++ b/samples/python/agents/vector_store_agent/config.py
@@ -1,0 +1,65 @@
+"""
+Configuration file for the Vector Store Agent.
+"""
+
+import os
+from typing import Optional, Dict, Any, List
+
+# Default OpenAI API configuration
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+DEFAULT_MODEL = os.environ.get("VECTOR_STORE_MODEL", "gpt-4.1-mini")
+VECTOR_STORE_ID = os.environ.get("VECTOR_STORE_ID")
+USE_MOCK = VECTOR_STORE_ID is None or VECTOR_STORE_ID == ""
+
+# Server configuration
+DEFAULT_HOST = os.environ.get("VECTOR_STORE_HOST", "localhost")
+DEFAULT_PORT = int(os.environ.get("VECTOR_STORE_PORT", "10050"))
+
+# Streaming configuration
+ENABLE_STREAMING = os.environ.get("VECTOR_STORE_ENABLE_STREAMING", "true").lower() == "true"
+STREAMING_CHUNK_SIZE = int(os.environ.get("VECTOR_STORE_CHUNK_SIZE", "20"))
+
+# Agent metadata
+AGENT_NAME = "Vector Store Knowledge Agent"
+AGENT_DESCRIPTION = (
+    "A general-purpose vector store query agent using OpenAI's Responses API"
+)
+AGENT_VERSION = "0.1.0"
+AGENT_ORGANIZATION = "Vector Store Research Team"
+
+# Query configuration
+DEFAULT_MAX_RESULTS = int(os.environ.get("VECTOR_STORE_MAX_RESULTS", "5"))
+DEFAULT_MODEL_PROMPT = """
+Based ONLY on the information provided in the retrieved documents, please answer the following query:
+
+{query}
+
+Provide a well-structured and comprehensive response that includes:
+1. A clear and direct answer to the query
+2. Key points from the relevant documents
+3. Citation of sources used
+
+If the information in the documents is insufficient to answer the query,
+please state this clearly and explain what information is missing.
+"""
+
+# Mock response configuration (used when no vector store is available)
+MOCK_RESPONSE_TEMPLATE = """
+# Results for: '{query}'
+
+## Top Relevant Results
+
+1. **Document 1**: Example document title
+   - Key information related to the query
+   - Additional context from this document
+
+2. **Document 2**: Secondary source
+   - Supporting information
+   - Additional context
+
+## Summary
+This is a simulated response generated when no vector store ID is provided.
+To get actual results, please set the VECTOR_STORE_ID environment variable.
+
+*Note: This is a mock response. To get real results, configure a vector store.*
+"""

--- a/samples/python/agents/vector_store_agent/pyproject.toml
+++ b/samples/python/agents/vector_store_agent/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "a2a-samples-vector-store"
+version = "0.1.0"
+description = "A general-purpose A2A agent that provides information from an OpenAI vector store using the Responses API"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "a2a-samples",
+    "openai>=1.3.0",
+    "click>=8.1.0",
+]
+
+[tool.uv.sources]
+a2a-samples = { workspace = true }

--- a/samples/python/pyproject.toml
+++ b/samples/python/pyproject.toml
@@ -29,6 +29,7 @@ members = [
     "hosts/multiagent",
     "agents/llama_index_file_chat",
     "agents/semantickernel",
+    "agents/vector_store_agent",
 ]
 
 [build-system]


### PR DESCRIPTION
This PR adds a new Vector Store Agent under `samples/python/agents/vector_store_agent/`.

Includes:
- `README.md` with usage and setup instructions
- `__main__.py` for launching the agent
- `agent.py` with the agent implementation
- `config.py` with environment and default settings
- `pyproject.toml` for agent dependencies
- `__init__.py`

Also updates:
- `samples/python/pyproject.toml` to include the new agent
- `samples/python/agents/README.md` to list the agent

This is a standalone addition with no other changes.