### PR TITLE
docs: add guide for connecting to agents via A2A server in demo UI

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -63,3 +63,23 @@ Click on the task list to see all the A2A task updates from the remote agents
     uv run main.py
     ```
 Note: The application runs on port 12000 by default
+
+## How to Communicate with Agents on the A2A Server
+
+### Prerequisites
+
+- Complete the steps in [Running the Examples](#running-the-examples) to start the local demo.
+    - Verify you can access `http://localhost:12000/`.
+
+- Start one of the sample agents from [Sample Agents](/samples/python/agents).
+    - Note the address (host and port) where your agent is running.
+
+### Steps
+
+1. Open `http://localhost:12000/agents` in your browser.
+
+1. Click the upload icon.
+
+1. Enter the address of your running agent (e.g., localhost:10002, without the protocol).
+
+Once added, you can start interacting with the agent through the web UI!


### PR DESCRIPTION
# Description
This PR adds a new section to the README titled "How to Communicate with Agents on the A2A Server", providing step-by-step instructions for connecting remote agents via the demo web UI.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).

# Motivation
Developers running the demo UI may be unsure how to connect their own agents. This documentation addition aims to simplify the process and reduce onboarding friction when testing A2A interactions locally.
