### PR TITLE
fix: allow agent host to define a custom host and port

### DIFF
--- a/demo/ui/state/host_agent_service.py
+++ b/demo/ui/state/host_agent_service.py
@@ -32,9 +32,9 @@ from .state import (
     StateTask,
 )
 
-
-server_url = 'http://localhost:12000'
-
+host = os.environ.get('A2A_AGENT_HOST', 'localhost')
+port = int(os.environ.get('A2A_AGENT_PORT', '12000'))
+server_url = f'http://{host}:{port}'
 
 async def ListConversations() -> list[Conversation]:
     client = ConversationClient(server_url)


### PR DESCRIPTION
# Description

I was trying to run locally two instances of the Demo UI + Agent Host, and noticed that even when I defined a different env var "A2A_UI_PORT" to run the Demo UI in another port everything was working but the state was shared between the two UI instances, because they pointed to the same Host Agent (hardcoded to run in localhost:12000).

To solve this I propose this change in the Demo UI code, to allow to also run two instances of Agent Host, each per instance of Demo UI.

This follows the same logic that was implemented here: https://github.com/google/A2A/blob/35f51ce9debe016541111e4a34b2d88fb1d830d2/demo/ui/main.py#L155-L160