### PR TITLE
feat: Add A2A minimal agent example and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,81 @@ As AI agents become more prevalent, their ability to interoperate is crucial for
     - `pip install a2a-sdk`
 - 🎬 Use our [samples](https://github.com/google-a2a/a2a-samples) to see A2A in action
 
+## Local Agent Development and Handshake
+
+This repository includes a minimal A2A agent example to help you understand local development and the basic A2A handshake process.
+
+### Running the Minimal Agent Example
+
+The example agent is located at `ionverse/libs/a2a_example.py`.
+
+1.  **Install Dependencies:**
+    Ensure you have the necessary Python packages installed. If you haven't already, create and activate a virtual environment:
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
+    pip install -r requirements.txt
+    ```
+
+2.  **Run the Agent:**
+    Execute the example script:
+    ```bash
+    python ionverse/libs/a2a_example.py
+    ```
+    The agent will start and listen on `http://localhost:8000/`. You should see output similar to:
+    ```console
+    INFO:     Started server process [xxxxx]
+    INFO:     Waiting for application startup.
+    INFO:     Application startup complete.
+    INFO:     Uvicorn running on http://localhost:8000 (Press CTRL+C to quit)
+    ```
+
+### Understanding the Handshake
+
+The A2A interaction model, even locally, follows these key steps:
+
+1.  **Agent Discovery (Agent Card):**
+    A client discovers an agent's capabilities by fetching its **Agent Card**. The minimal example agent exposes its card at:
+    `http://localhost:8000/.well-known/agent.json`
+
+    You can try opening this URL in your browser or using `curl`:
+    ```bash
+    curl http://localhost:8000/.well-known/agent.json
+    ```
+    This JSON response describes the agent (name, description, URL, skills, capabilities, etc.). The `Minimal A2A Agent` has a skill with `id: 'minimal_echo'`.
+
+2.  **Initiating a Task (Message Send):**
+    Once a client knows about an agent and its skills, it can send messages to initiate tasks. A2A uses JSON-RPC 2.0 over HTTP. For the `minimal_echo` skill, a client would send a request to the agent's URL (`http://localhost:8000/`) to invoke this skill.
+
+    For example, to send a simple text message, the client would construct a JSON-RPC request like this (conceptual example):
+    ```json
+    {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": "client-message-123",
+                "role": "user",
+                "parts": [
+                    {
+                        "type": "TextPart",
+                        "text": "Hello Agent!"
+                    }
+                ]
+            }
+            // Optionally, specify skillId if the agent has multiple skills
+            // and the default isn't desired, or to be explicit.
+            // "skillId": "minimal_echo"
+        },
+        "id": "rpc-request-1"
+    }
+    ```
+    The agent would then process this and respond, in the case of our minimal agent, with "Hello from Minimal A2A Agent!".
+
+    *Note: Interacting via `curl` for anything beyond fetching the Agent Card can be complex due to JSON-RPC formatting. Typically, you'd use an A2A client library or tool.*
+
+This example provides a basic illustration of how an A2A agent advertises its capabilities and how a client might begin an interaction. Refer to the full [A2A Protocol Specification](https://google-a2a.github.io/A2A/specification/) for detailed information on all methods, task lifecycles, and data types.
+
 ## Contributing
 
 We welcome community contributions to enhance and evolve the A2A protocol!

--- a/ionverse/libs/a2a_example.py
+++ b/ionverse/libs/a2a_example.py
@@ -1,0 +1,89 @@
+import uvicorn
+
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+)
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.utils import new_agent_text_message
+
+# Minimal Agent Logic (from helloworld's agent_executor.py)
+class MinimalAgent:
+    """Minimal Agent Logic."""
+
+    async def invoke(self) -> str:
+        return 'Hello from Minimal A2A Agent!'
+
+class MinimalAgentExecutor(AgentExecutor):
+    """Minimal Agent Executor."""
+
+    def __init__(self):
+        self.agent = MinimalAgent()
+
+    async def execute(
+        self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> None:
+        result = await self.agent.invoke()
+        event_queue.enqueue_event(new_agent_text_message(result))
+
+    async def cancel(
+        self, context: RequestContext, event_queue: EventQueue
+    ) -> None:
+        # For a minimal agent, explicit cancellation might not be supported
+        # or could be simplified. Raising an error or logging is an option.
+        # Depending on DefaultRequestHandler, it might also handle this.
+        # For true minimality, we can state it's not supported.
+        raise NotImplementedError('Cancel operation is not supported by this minimal agent.')
+
+if __name__ == '__main__':
+    # Define the agent's skill
+    minimal_skill = AgentSkill(
+        id='minimal_echo',
+        name='Minimal Echo Skill',
+        description='Echoes a simple message from the agent.',
+        tags=['minimal', 'echo'],
+        examples=['ping', 'say hi'],
+        inputModes=['text/plain'], # Optional: specify if different from agent default
+        outputModes=['text/plain'], # Optional: specify if different from agent default
+    )
+
+    # Define the Agent Card
+    agent_card = AgentCard(
+        name='Minimal A2A Agent',
+        description='A very basic A2A agent example for Ionverse.',
+        url='http://localhost:8000/', # Adjusted port
+        version='0.1.0',
+        defaultInputModes=['text/plain'],
+        defaultOutputModes=['text/plain'],
+        capabilities=AgentCapabilities(streaming=True), # Retaining streaming capability
+        skills=[minimal_skill],
+        # No authentication for this minimal example
+        # supportsAuthenticatedExtendedCard=False (or omit)
+    )
+
+    # Set up the request handler
+    request_handler = DefaultRequestHandler(
+        agent_executor=MinimalAgentExecutor(),
+        task_store=InMemoryTaskStore(), # Simple in-memory store for tasks
+    )
+
+    # Create the A2A application
+    server_app_builder = A2AStarletteApplication(
+        agent_card=agent_card,
+        http_handler=request_handler,
+        # No extended_agent_card for minimal example
+    )
+
+    # Run the server with Uvicorn
+    uvicorn.run(
+        server_app_builder.build(),
+        host='0.0.0.0',
+        port=8000 # Adjusted port
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+a2a-sdk
+uvicorn


### PR DESCRIPTION
This commit introduces a minimal A2A agent example and supporting infrastructure:

- Creates `ionverse/libs/a2a_example.py`: A runnable minimal A2A agent based on the A2A Python SDK's helloworld example. It demonstrates basic agent card setup, skill definition, and an echo-like functionality.
- Creates `requirements.txt`: Adds `a2a-sdk` and `uvicorn` as dependencies required to run the example agent.
- Updates `README.md`: Adds a new section "Local Agent Development and Handshake". This section details:
    - How to install dependencies and run the `a2a_example.py`.
    - An explanation of the A2A handshake process (Agent Card discovery, task initiation via message/send).
    - Example `curl` command to fetch the Agent Card.
    - Conceptual JSON-RPC example for sending a message to the agent.

These changes facilitate local development and understanding of the A2A protocol within the Ionverse project.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/A2A/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
