### PR TITLE
docs: Add `@TJS-examples` for `AgentProvider` and `AgentExtension` interfaces

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -56,6 +56,7 @@ RPCs
 RUF
 SLAs
 SLF
+TJS
 TMDB
 URLTo
 Upserting

--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -222,6 +222,13 @@
         },
         "AgentExtension": {
             "description": "A declaration of an extension supported by an Agent.",
+            "examples": [
+                {
+                    "description": "Google OAuth 2.0 authentication",
+                    "required": false,
+                    "uri": "https://developers.google.com/identity/protocols/oauth2"
+                }
+            ],
             "properties": {
                 "description": {
                     "description": "A description of how this agent uses this extension.",
@@ -248,6 +255,12 @@
         },
         "AgentProvider": {
             "description": "Represents the service provider of an agent.",
+            "examples": [
+                {
+                    "organization": "Google",
+                    "url": "https://ai.google.dev"
+                }
+            ],
             "properties": {
                 "organization": {
                     "description": "Agent provider's organization name.",

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -5,7 +5,7 @@
 // --8<-- [start:AgentProvider]
 /**
  * Represents the service provider of an agent.
- * @example { organization: "Google", url: "https://ai.google.dev" }
+ * @TJS-examples [{ "organization": "Google", "url": "https://ai.google.dev" }]
  */
 export interface AgentProvider {
   /** Agent provider's organization name. */
@@ -34,7 +34,7 @@ export interface AgentCapabilities {
 // --8<-- [start:AgentExtension]
 /**
  * A declaration of an extension supported by an Agent.
- * @example { uri: "https://developers.google.com/identity/protocols/oauth2", description: "Google OAuth 2.0 authentication", required: false }
+ * @TJS-examples [{"uri": "https://developers.google.com/identity/protocols/oauth2", "description": "Google OAuth 2.0 authentication", "required": false}]
  */
 export interface AgentExtension {
   /** The URI of the extension. */

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -5,6 +5,7 @@
 // --8<-- [start:AgentProvider]
 /**
  * Represents the service provider of an agent.
+ * @example { organization: "Google", url: "https://ai.google.dev" }
  */
 export interface AgentProvider {
   /** Agent provider's organization name. */
@@ -33,6 +34,7 @@ export interface AgentCapabilities {
 // --8<-- [start:AgentExtension]
 /**
  * A declaration of an extension supported by an Agent.
+ * @example { uri: "https://developers.google.com/identity/protocols/oauth2", description: "Google OAuth 2.0 authentication", required: false }
  */
 export interface AgentExtension {
   /** The URI of the extension. */


### PR DESCRIPTION
Add missing JSDoc `@example` annotations to `AgentProvider` and `AgentExtension` interfaces to improve TypeScript developer experience.

Examples use Google ecosystem references (ai.google.dev, OAuth 2.0) and follow existing JSDoc patterns in the codebase.

First contribution to open source ❤️